### PR TITLE
Render metadata for all extracts without inserting `{ render_standard_metadata() }` macro into each markdown file

### DIFF
--- a/docs/extracts/EN_ISO_12855/index.md
+++ b/docs/extracts/EN_ISO_12855/index.md
@@ -11,8 +11,6 @@ annotation: "This Extract does not replace the technical standard itself; it is 
 note: "Note: This Extract presents selected chapters of the described document and retains the original chapter numbering."
 ---
 
-{{ render_standard_metadata() }}
-
 ## Introduction
 
 This technical standard (hereinafter also referred to as the “described document”) specifies the interface for the exchange of data messages between the main entities (roles) of the electronic fee collection system architecture, i.e., the toll charger and the toll service provider. It establishes the complete specification of data messages, their syntax, semantics, and the mechanism of their transmission.

--- a/docs/extracts/EN_ISO_14906/index.md
+++ b/docs/extracts/EN_ISO_14906/index.md
@@ -11,13 +11,6 @@ annotation: "This Extract does not replace the technical standard itself; it is 
 note: "Note: This Extract presents selected chapters of the described document and retains the original chapter numbering."
 ---
 
-_**{{ page.meta.name }}**_
-
-!!! note
-    Published: in {{ page.meta.published }} (Edition {{ page.meta.edition }}), {{ page.meta.pages }} pages
-
-    This Extract does not replace the technical standard itself; it is only informative material about the standard.
-
 ## Introduction
 
 This technical standard (hereinafter also referred to as the "described document") specifies the application interface for electronic fee collection (EFC) systems that utilize dedicated short-range communication (DSRC). Specifically, it establishes the technical conditions for the EFC transaction model, EFC functions, and EFC data attributes from which an EFC transaction can be created in a DSRC environment.

--- a/docs/extracts/EN_ISO_17573-1/index.md
+++ b/docs/extracts/EN_ISO_17573-1/index.md
@@ -11,8 +11,6 @@ annotation: "This Extract does not replace the technical standard itself; it is 
 note: "Note: This Extract presents selected chapters of the described document and retains the original chapter numbering."
 ---
 
-{{ render_standard_metadata() }}
-
 ## Introduction
 
 This standard, consisting of a single part (hereinafter referred to as the "described document"), defines the architecture for tolling environments. In these environments, a user who has a contract with only one Service Provider can use their vehicle across various Toll Domains operated by different Toll Chargers.

--- a/docs/extracts/ISO_14823-1/index.md
+++ b/docs/extracts/ISO_14823-1/index.md
@@ -11,8 +11,6 @@ annotation: "This Extract does not replace the technical standard itself; it is 
 note: "Note: This Extract presents selected chapters of the described document and retains the original chapter numbering."
 ---
 
-{{ render_standard_metadata() }}
-
 ## Introduction
 
 The standard ISO 14823-1:2024 defines the **Graphic Data Dictionary (GDD)** – a unified, language-independent system for encoding traffic signs and pictograms for the needs of Intelligent Transport Systems (ITS). Its purpose is to enable **efficient transmission, interpretation, and display of traffic information** across different countries, systems, and technologies. This dictionary is used for information exchange between centres (DATEX II) and between infrastructure and vehicles (cooperative systems, C-ITS) for describing traffic signs displayed, for example, on variable message signs.

--- a/docs/extracts/ISO_15622/index.md
+++ b/docs/extracts/ISO_15622/index.md
@@ -12,8 +12,6 @@ annotation: "This Extract does not replace the technical standard itself; it is 
 note: "Note: This Extract presents selected chapters of the described document and retains the original chapter numbering."
 ---
 
-{{ render_standard_metadata() }}
-
 ## Introduction
 
 This standard belongs to the family of standards dealing with driver assistance systems and intelligent transport systems. The main function of Adaptive Cruise Control (ACC) is to control vehicle speed adaptively relative to a forward vehicle by using information concerning: (1) the distance to forward vehicles, (2) the motion of the subject vehicle equipped with ACC, and (3) driver commands. Based on the acquired information, the controller (ACC control strategy) transmits commands to the actuators responsible for longitudinal vehicle control and simultaneously provides status information to the driver (see Figure 1).

--- a/docs/extracts/ISO_17748-3/index.md
+++ b/docs/extracts/ISO_17748-3/index.md
@@ -11,8 +11,6 @@ annotation: "This Extract does not replace the technical standard itself; it is 
 note: "Note: The extract lists selected chapters of the described document and adopts the original chapter numbering."
 ---
 
-{{ render_standard_metadata() }}
-
 ## Introduction
 
 This standard defines data exchange requirements to support Electric Vehicle (EV)-based Demand Response (DR) services utilizing nomadic devices, considering two types of EV-based DR services. One is to reduce demand of electric vehicles charging when there is a shortage on the grid side. The other is to increase demand of electric vehicles charging when the surplus on the grid side is forecasted day ahead.

--- a/docs/extracts/ISO_21214/index.md
+++ b/docs/extracts/ISO_21214/index.md
@@ -12,8 +12,6 @@ annotation: "This Extract does not replace the technical standard itself; it is 
 note: "Note: This Extract presents selected chapters of the described document and retains the original chapter numbering."
 ---
 
-{{ render_standard_metadata() }}
-
 ## Introduction
 
 The ISO 21214 international standard (hereinafter referred to as the described document) introduces a set of functional requirements for the communication interface of an ITS station.

--- a/docs/extracts/ISO_23792-1/index.md
+++ b/docs/extracts/ISO_23792-1/index.md
@@ -11,8 +11,6 @@ annotation: "This Extract does not replace the technical standard itself; it is 
 note: "Note: This Extract presents selected chapters of the described document and retains the original chapter numbering."
 ---
 
-{{ render_standard_metadata() }}
-
 ## Introduction
 
 This document specifies a framework and general requirements for Level 3 automated driving systems intended for motorway operation. The standard defines the concept of a Motorway Chauffeur System (MCS) as a specific implementation of an automated driving system (ADS) that performs the entire dynamic driving task (DDT) within the current lane of travel in the presence of a fallback-ready user (FRU). The document establishes a systematic framework including system characteristics, operational design domain (ODD), state models and state transitions, functional requirements, minimum DDT performance requirements, and test scenarios.

--- a/docs/extracts/ISO_26683-2/index.md
+++ b/docs/extracts/ISO_26683-2/index.md
@@ -11,8 +11,6 @@ annotation: "This Extract does not replace the technical standard itself; it is 
 note: "Note: The Extract presents selected chapters of the described document and retains the original chapter numbering."
 ---
 
-{{ render_standard_metadata() }}
-
 ## Introduction
 
 The ISO 26683 (FLC‑CIC) set of standards uses advanced information and communication technology for freight transport, focusing on the presentation of data when providing end‑to‑end services related to cargo and their means of transport. It does not provide a system design, nor does it specify the technologies to be used.

--- a/docs/extracts/ISO_4448-1/index.md
+++ b/docs/extracts/ISO_4448-1/index.md
@@ -11,8 +11,6 @@ annotation: "This Extract does not replace the technical standard itself; it is 
 note: "Note: This Extract presents selected clauses of the described document and retains the original clause numbering."
 ---
 
-{{ render_standard_metadata() }}
-
 ## Introduction
 
 In 2023, there are several hundred companies around the world – mostly start-ups – engaged in the development of small, remote-controlled and sometimes partially automated devices for operation on city sidewalks and cycle paths. Thousands of small retailers and dozens of delivery companies use these systems for last-mile delivery. Already, many more cities have a small number of such PMRs than robotic taxis in pilot operation. This means that cities are likely to face PMR regulation requirements much sooner than the regulation of robotic cars and trucks is expected.

--- a/docs/extracts/ISO_TS_19091/index.md
+++ b/docs/extracts/ISO_TS_19091/index.md
@@ -12,8 +12,6 @@ annotation: "This Extract does not replace the technical standard itself; it is 
 note: "Note: This Extract presents selected chapters of the described document and retains the original chapter numbering."
 ---
 
-{{ render_standard_metadata() }}
-
 ## Introduction
 
 ISO/TS 19091 (hereinafter referred to as "this document") describes the use cases for several applications in the domain of signalized intersections, the goal of which is to improve safety, mobility, and environmental sustainability. For each use case, the information needs are defined that must be fulfilled through communication between vehicles and the infrastructure. In this way, the requirements for individual applications are defined, and these are subsequently mapped to data frames and data elements through which the individual requirements are fulfilled within the defined message set.

--- a/docs/extracts/ISO_TS_22726-1/index.md
+++ b/docs/extracts/ISO_TS_22726-1/index.md
@@ -12,8 +12,6 @@ annotation: "This Extract does not replace the technical standard itself; it is 
 note: "Note: This Extract presents selected chapters of the described document and retains the original chapter numbering."
 ---
 
-{{ render_standard_metadata() }}
-
 ## Introduction
 
 The ISO/TS 22726 series was created in response to the need to unify the way **static map data for automated driving (ADS)** are represented and stored. Modern vehicles with a high degree of automation require extremely precise, consistent, and rapidly accessible map data that link detailed descriptions of infrastructure with dynamic traffic information. Existing standards — such as ISO 14296 or GDF 5.1 - cover navigation or data exchange between providers, but they are not optimized for **runtime access in onboard systems** nor for representing detailed elements such as lanes, their topology, precise geometries, or relationships to traffic events.

--- a/docs/extracts/ISO_TS_22741-10/index.md
+++ b/docs/extracts/ISO_TS_22741-10/index.md
@@ -11,8 +11,6 @@ annotation: "This Extract does not replace the technical standard itself; it is 
 note: "Note: This Extract presents selected chapters of the described document and retains the original chapter numbering."
 ---
 
-{{ render_standard_metadata() }}
-
 ## Introduction
 
 The ISO 22741-10 standard (hereinafter referred to as 'the described document') is part of a set of standards that define the principles of information exchange between infrastructure devices and traffic centres using AP-DATEX (an application profile of DATEX II, which serves for the exchange of traffic data between various information systems).

--- a/macros.py
+++ b/macros.py
@@ -1,3 +1,16 @@
+def on_pre_page_macros(env):
+    """
+    Automatically inject the standard metadata box into extract pages
+    so source files don't need an explicit {{ render_standard_metadata() }} call.
+
+    Fires before Jinja2 processes the page. Only extract pages set the
+    'standard' front matter key, so that is used as the selector. Guard
+    against double-injection in case a file still has the explicit call.
+    """
+    if "standard" in env.page.meta and "render_standard_metadata" not in env.markdown:
+        env.markdown = "{{ render_standard_metadata() }}\n\n" + env.markdown
+
+
 def define_env(env):
     """Define macros and variables for MkDocs."""
 


### PR DESCRIPTION
## Documentation Update Template

### Related Issue(s)

Fixes #111

### Type of Change
Simplify how extract markdowns are used.

### Summary of the Update
- Relates to extracts
- using hook to insert front-matter processing macro automatically.

### **Type of Documentation Update**
Select the type of documentation update you are submitting:

- [ ] Extracts

### **Checklist**
Before submitting, please ensure the following items are checked:
